### PR TITLE
Build boost with debug symbols (full stack traces) — v1.89.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ DIST_VERSION = 1_89_0
 # Release version on GitHub - bump last digit to make new
 # GitHub release with same distribution version.
 NAME = boost
-VERSION =  1.89.1
+VERSION =  1.89.2
 
 #
 # Download location URL
@@ -327,7 +327,7 @@ $(MAKER_BUILDROOT_DIR)/$(1)/$(2)/$(FRAMEWORKBUNDLE)$(INSTALLED_LIB) :
 	cd $(PKGSRCDIR) && \
 	PATH=usr/local/bin:/usr/bin:/bin \
 	BOOST_BUILD_USER_CONFIG=$(MAKER_BUILD_DIR)/$(1)/$(2)/user-config.jam \
-	./b2 --build-dir="$$$$builddir" --prefix="$$$$installdir" $$(JAM_OPTIONS) toolset=clang-darwin-$(4) target-os=$(3) warnings=off link=static $$(JAM_PROPERTIES) install && \
+	./b2 --build-dir="$$$$builddir" --prefix="$$$$installdir" $$(JAM_OPTIONS) toolset=clang-darwin-$(4) target-os=$(3) warnings=off link=static debug-symbols=on $$(JAM_PROPERTIES) install && \
 	cd $$$$installdir/lib && printf "[$(1)-$(2)] extracting... " && \
 	for ar in `find . -name "*.a"` ; do \
 		boostlib=`basename $$$$ar` ; \

--- a/notes/RELNOTES-1.89.2
+++ b/notes/RELNOTES-1.89.2
@@ -1,0 +1,28 @@
+Build Boost with debug symbols (full stack traces)
+
+The static libraries are now compiled with debug symbols retained
+(b2 `debug-symbols=on`), so consumers get full, symbolicated stack
+traces (file/line, not just function names) and a non-empty dSYM when
+archiving an app that links boost.
+
+Previously the release build stripped DWARF, leaving only the symbol
+table — backtraces through boost showed addresses/names but no source
+locations, and the app archive produced an empty dSYM for the boost
+slice.
+
+This supports the following platforms:
+
+* iphoneos/arm64
+* iphonesimulator/arm64
+* iphonesimulator/x86_64
+* macosx/arm64
+* macosx/x86_64
+
+## Fixed issues
+
+* Compile with `debug-symbols=on` so DWARF is retained in the static
+  archive members (FleetSafer AB#25).
+
+## Deprecations:
+
+The x86_64 iphonesimulator architecture is not built on MacOSX Tahoe (Xcode26+)


### PR DESCRIPTION
## What
Build the boost static libraries with `debug-symbols=on` so DWARF is retained, giving consumers **full symbolicated stack traces** (file/line, not just function names) and a non-empty dSYM when archiving an app that links boost.

## Why
The release-variant b2 build stripped DWARF — backtraces through boost showed only names, and an app archive produced an empty dSYM for the boost slice. Tracked as FleetSafer **AB#25** ("shipping a library with no debug symbols → empty dSYM").

## Changes
- `Makefile`: add `debug-symbols=on` to the b2 invocation (optimized-with-symbols; no deoptimization). Bump `VERSION` 1.89.1 → **1.89.2**.
- `notes/RELNOTES-1.89.2`: release notes (gates the pipeline's release job).

## Release flow (on merge to master)
Azure pipeline builds all slices → `make xcframework` → cuts **Boost-iOS 1.89.2** binary release + updates `Package.swift` (version + checksum). FleetSafer then bumps its `boost-ios` pin to 1.89.2 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)