### PR TITLE
CI: fail loud when the boost build produces no artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,8 @@ jobs:
         persistCredentials: true
         fetchTags: true
       - script: |
+          set -euo pipefail
+
           version=$(make version)
           echo "##vso[task.setvariable variable=moduleVersion;isOutput=true]$version"
 
@@ -64,6 +66,15 @@ jobs:
             make SDK=$sdk
           done
           make xcframework
+
+          # Fail loud if the build produced no artifact. A stripped/empty build
+          # (e.g. an unlicensed Xcode on the agent — `sudo xcodebuild -license
+          # accept`) otherwise reports success and cuts an empty release.
+          if [ ! -f "$(moduleName).xcframework.zip" ] ; then
+            echo "##vso[task.logissue type=error]$(moduleName).xcframework.zip was not produced - build did not run (check Xcode license / toolchain on the agent)"
+            exit 1
+          fi
+
           if [ -f notes/RELNOTES-$version ] ; then
             make GITBRANCH=$(Build.SourceBranchName) release
           fi


### PR DESCRIPTION
## Why
Build 627 (the 1.89.2 build after merging #12) reported **success while producing nothing**: the `Steves-Mac-Mini` agent's Xcode license wasn't accepted, so every `xcrun`/`xcodebuild` call failed with *"You have not agreed to the Xcode license agreements"*, the build no-op'd, `CopyFiles` found 0 files, and the release was silently skipped — all on a green build.

## What
Harden the `build` step:
- `set -euo pipefail` — a failing `make SDK=…` / `make xcframework` now aborts the job instead of being ignored.
- Explicit guard: error out if `boost.xcframework.zip` wasn't produced, with a message pointing at the likely cause (Xcode license / toolchain on the agent).

No build-logic change — this just turns a broken build into a loud failure instead of cutting an empty release.

## Note
The underlying agent issue (Xcode license on Steves-Mac-Mini) is being fixed separately; merging this also kicks off a fresh master build, which should now compile 1.89.2 for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)