### PR TITLE
CI: Publish/Release master-only (skip on feature/* + PR)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,10 @@ jobs:
     workspace:
       clean: all
     dependsOn: Build
-    condition: and(succeeded('Build'),not(canceled()))
+    # Publish (and Release) only from master — feature/* and PR builds validate
+    # the xcframework in Build but must never push Package.swift / tag / release
+    # to the Boost-iOS repo.
+    condition: and(succeeded('Build'),not(canceled()),eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: Publish SPM metadata Package.swift
     variables:
       moduleVersion: $[ dependencies.Build.outputs['build.moduleVersion'] ]
@@ -140,7 +143,7 @@ jobs:
     dependsOn:
       - Build
       - Publish
-    condition: and(and(succeeded('Publish'),not(canceled())),eq(dependencies.Publish.outputs['publish.createRelease'], 'true'))
+    condition: and(and(succeeded('Publish'),not(canceled())),and(eq(dependencies.Publish.outputs['publish.createRelease'], 'true'),eq(variables['Build.SourceBranch'], 'refs/heads/master')))
     displayName: Release binary SPM XCFramework
     variables:
       moduleVersion: $[ dependencies.Build.outputs['build.moduleVersion'] ]


### PR DESCRIPTION
## Why
The `feature/pipeline-fail-loud` CI build **failed in the Publish step**: the `Publish` job gated only on `succeeded('Build')` with no branch condition, so it ran on the feature branch and tried to push `Package.swift` + tag/release to the **Boost-iOS** repo. Publishing the binary SPM package must be **master-only**; feature/* and PR builds should build + verify the xcframework and stop.

## Fix
- `Publish` condition: add `eq(variables['Build.SourceBranch'], 'refs/heads/master')`.
- `Release` condition: add the same master gate (it already chained off `Publish`'s `createRelease` output, but make it explicit/robust).

`Build` is unchanged — it still validates the xcframework on every branch (and its `make release` step is independently gated to master inside the Makefile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)