### PR TITLE
Prepare Release 1.89.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ DIST_VERSION = 1_89_0
 # Release version on GitHub - bump last digit to make new
 # GitHub release with same distribution version.
 NAME = boost
-VERSION =  1.89.1
+VERSION =  1.89.3
 
 #
 # Download location URL

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ To add the swift package right click your project in the Xcode project explorer,
 select __Add packages...__.
 * In the search field enter the package URL __https://github.com/Cogosense/Boost-iOS__
 * In the __Dependency Rule__ field set the version to __1.89.0__
+
+## Creating a New Boost-iOS SPM Binary Release
+
+1. Create a release branch
+
+   git checkout release/x.y.z
+
+2. Set the **VERSION** variable in the _Makefile_ to the new release version string (x.y.z).
+3. Create a release notes file in the notes directory with name **RELNOTES-x.y.z** (The release will not happen if this file is missing).
+5. Add, commit and push the updated _Makefile_ and the _notes/RELNOTES-x.y.z_
+6. Create a PR request to merge to master
+
+The pipeline build will run automatically when the PR is approved, creating the
+new release in the _Cogosense/Boost-iOS_ GitHub repo.
+
 ## Platform Support
 
 The Makefile in this project creates a iOS XCframework bundle that

--- a/notes/RELNOTES-1.89.3
+++ b/notes/RELNOTES-1.89.3
@@ -1,0 +1,21 @@
+Boost v1.89.0
+
+This framework was built with Xcode26.3.
+
+This supports the following platforms:
+
+* iphoneos/arm64
+* iphonesimulator/arm64
+* macosx/arm64
+* macosx/x86_64
+
+## Fixed issues
+
+* Added debug information so App DSYM bundles are correctly created to debug stack traces
+* Added the json and iostreams libraries.
+
+## Deprecations:
+
+The x86_64 iphonesimulator architecture is still supported by iOSBoostFramework
+but not built by default on Xcode26+ so is not included in this Boost-iOS
+release.


### PR DESCRIPTION
Added json and iostreams support.
Enabled debug symbols so DSYMs are correctly generated.